### PR TITLE
Please consider the inclusion of a turnRight() function

### DIFF
--- a/Sources/MerlinKarel/KarelExecutor.swift
+++ b/Sources/MerlinKarel/KarelExecutor.swift
@@ -133,6 +133,19 @@ open class KarelExecutor {
         karel.animateTurnLeft()
         semaphore.wait()
     }
+    // Turn karel clockwise ninety degrees
+        public func turnRight() {
+        guard !isTerminated else {
+            return
+        }
+        guard let karel = karel else {
+            fatalError("karel is required for turnRight()")
+        }
+        printKarel(isSuccessful: true, "turnRight()")
+        
+        karel.animateTurnRight()
+        semaphore.wait()
+    }
 
     // Place a beeper at the current corner (multiple beepers may be placed)
     public func putDownBeeper() {


### PR DESCRIPTION
*note this PR is for suggestion / discussion  


Hello, Mr. Ben, I got bored and thought about what would be the fastest way to beat the Karel missions. In that pursuit, I thought it was silly that there was no "turnRight()" native function because the [python](https://github.com/alts/karel) and [kotlin](https://github.com/fredoverflow/karel) implementations have a "turn_right()" function. Was this a intended feature or a unintended glitch?



#  I have not tested this (probably won't work at all), but I was wondering if this would work at all so do not merge. 